### PR TITLE
[Fix] Cannot read property 'permissions' of null

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -75,7 +75,7 @@ client.on('messageCreate', async msg => {
   const guild = msg.guild.id;
 
   const ts = parseInt((Date.now() / 1e3).toFixed());
-  const isAdmin = msg.member.permissions?.has(Permissions.FLAGS.ADMINISTRATOR) || false;
+  const isAdmin = msg.member?.permissions?.has(Permissions.FLAGS.ADMINISTRATOR) || false;
 
   if (msg.content === '!ping') msg.reply('Pong?');
 


### PR DESCRIPTION
```
TypeError: Cannot read property 'permissions' of null
at /app/src/discord.ts:78:30
    at Generator.next (<anonymous>)
    at /app/src/discord.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/app/src/discord.ts:4:12)
```